### PR TITLE
0.3.0: generics_inner, raw-identifier-safe field bindings, nested-paren protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "rules_derive"
-version = "0.2.0"
+version = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rules_derive"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 description = "simple and fast derive macros using macro_rules"

--- a/README.md
+++ b/README.md
@@ -55,12 +55,12 @@ pub enum Foo<T: Clone = u8> where u8: Into<T> {
 }
 
 // rules_derive-transformed type definition:
-((#[rustfmt::skip])) 
-pub enum Foo((Foo<T>) (<T: Clone>) where (u8: Into<T>,))
+((#[rustfmt::skip]))
+pub enum Foo ((Foo<T>) (<T: Clone>) (T: Clone) where (u8: Into<T>,))
 {
-    A(named Foo::A) { field__x @ x : T, } 
-    B(unit Foo::B) {}
-    C(unnamed Foo::C) { field__0 @ 0 : u8, }
+    A (named Foo::A) { f_x @ x : T, }
+    B (unit Foo::B) {}
+    C (unnamed Foo::C) { tuple_field_0 @ 0 : u8, }
 }
 ```
 

--- a/examples/binary_serialization.rs
+++ b/examples/binary_serialization.rs
@@ -38,7 +38,7 @@ impl_integer!(u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize);
 macro_rules! BinarySerializable {
   (
     ($( ($($attr:tt)*) )*)
-    $vis:vis $tystyle:ident $name:ident ($ty:ty) $(< ($($generics_bindings:tt)*) >)? where ($($generics_where:tt)*) {
+    $vis:vis $tystyle:ident $name:ident (($ty:ty) ($($generics_bindings:tt)*) ($($generics_inner:tt)*) where ($($generics_where:tt)*)) {
       $(
         $variant_name:ident ($variant_style:ident $($qualified_variant:tt)*) $(= ($discriminant:expr))? {
           $(
@@ -49,7 +49,7 @@ macro_rules! BinarySerializable {
     }
   ) => {
     ::rules_derive::with_spans! {
-      impl $(< $($generics_bindings)* >)? $crate::BinarySerializable for $ty where
+      impl $($generics_bindings)* $crate::BinarySerializable for $ty where
         $($generics_where)*
         $(
           $(

--- a/examples/clone.rs
+++ b/examples/clone.rs
@@ -3,7 +3,7 @@ use rules_derive::rules_derive;
 macro_rules! Clone {
   (
     ($( ($($attr:tt)*) )*)
-    $vis:vis $tystyle:ident $name:ident ($ty:ty) $(< ($($generics_bindings:tt)*) >)? where ($($generics_where:tt)*) {
+    $vis:vis $tystyle:ident $name:ident (($ty:ty) ($($generics_bindings:tt)*) ($($generics_inner:tt)*) where ($($generics_where:tt)*)) {
       $(
         $variant_name:ident ($variant_style:ident $($qualified_variant:tt)*) $(= ($discriminant:expr))? {
           $(
@@ -14,7 +14,7 @@ macro_rules! Clone {
     }
   ) => {
     ::rules_derive::with_spans! {
-      impl $(< $($generics_bindings)* >)? ::std::clone::Clone for $ty where
+      impl $($generics_bindings)* ::std::clone::Clone for $ty where
         $($generics_where)*
         $(
           $(

--- a/examples/custom_clone_and_eq.rs
+++ b/examples/custom_clone_and_eq.rs
@@ -17,7 +17,7 @@ pub trait CustomClone {
 macro_rules! CustomEq {
   (
     ($( ($($attr:tt)*) )*)
-    $vis:vis $tystyle:ident $name:ident ($ty:ty) $(< ($($generics_bindings:tt)*) >)? where ($($generics_where:tt)*) {
+    $vis:vis $tystyle:ident $name:ident (($ty:ty) ($($generics_bindings:tt)*) ($($generics_inner:tt)*) where ($($generics_where:tt)*)) {
       $(
         $variant_name:ident ($variant_style:ident $($qualified_variant:tt)*) $(= ($discriminant:expr))? {
           $(
@@ -28,7 +28,7 @@ macro_rules! CustomEq {
     }
   ) => {
     with_spans! {
-      impl $(< $($generics_bindings)* >)? $crate::CustomEq for $ty where
+      impl $($generics_bindings)* $crate::CustomEq for $ty where
         $($generics_where)*
         $(
           $(
@@ -64,7 +64,7 @@ macro_rules! CustomEq {
 macro_rules! CustomClone {
   (
     ($( ($($attr:tt)*) )*)
-    $vis:vis $tystyle:ident $name:ident ($ty:ty) $(< ($($generics_bindings:tt)*) >)? where ($($generics_where:tt)*) {
+    $vis:vis $tystyle:ident $name:ident (($ty:ty) ($($generics_bindings:tt)*) ($($generics_inner:tt)*) where ($($generics_where:tt)*)) {
       $(
         $variant_name:ident ($variant_style:ident $($qualified_variant:tt)*) $(= ($discriminant:expr))? {
           $(
@@ -75,7 +75,7 @@ macro_rules! CustomClone {
     }
   ) => {
     with_spans! {
-      impl $(< $($generics_bindings)* >)? $crate::CustomClone for $ty where
+      impl $($generics_bindings)* $crate::CustomClone for $ty where
         $($generics_where)*
         $(
           $(
@@ -227,8 +227,21 @@ impl CustomClone for u16 {
   fn custom_clone(&self) -> Self { *self }
 }
 
+// Raw-identifier fields (e.g. `r#if`, `r#loop`) must work. Exercises the
+// `f_<name>` field binding (the `r#` prefix is stripped when forming the
+// binding identifier).
+#[allow(dead_code)]
+#[rules_derive(CustomEq, CustomClone)]
+pub struct RawIdentStruct {
+  pub r#if: u8,
+  pub r#loop: u16,
+}
+
 fn main() {
   assert!(DiscriminantEnum::A
     .custom_clone()
     .custom_eq(&DiscriminantEnum::A));
+
+  let raw = RawIdentStruct { r#if: 7, r#loop: 9 };
+  assert!(raw.custom_eq(&raw.custom_clone()));
 }

--- a/examples/enum_from_string.rs
+++ b/examples/enum_from_string.rs
@@ -10,7 +10,7 @@ pub trait EnumFromString: Sized {
 macro_rules! EnumFromString {
   (
     $attrs:tt
-    $vis:vis /* require enum */ enum $name:ident ($ty:ty) $(< ($($generics_bindings:tt)*) >)? where ($($generics_where:tt)*) {
+    $vis:vis /* require enum */ enum $name:ident (($ty:ty) ($($generics_bindings:tt)*) ($($generics_inner:tt)*) where ($($generics_where:tt)*)) {
       $(
         $variant_name:ident (/* require unit variant */ unit $($qualified_variant:tt)*) $(= ($discriminant:expr))? {
           // We deliberately don't accept any fields. These matchers are elided:
@@ -21,7 +21,7 @@ macro_rules! EnumFromString {
       )*
     }
   ) => {
-    impl $(< $($generics_bindings)* >)? $crate::EnumFromString for $ty where $($generics_where)*
+    impl $($generics_bindings)* $crate::EnumFromString for $ty where $($generics_where)*
     {
       fn from_str(x: &str) -> ::std::option::Option<Self> {
         // We create named constants for each variant name, to allow us to use a `match` expression.

--- a/examples/heap_size.rs
+++ b/examples/heap_size.rs
@@ -13,7 +13,7 @@ pub trait HeapSize {
 macro_rules! HeapSize {
   (
     ($( ($($attr:tt)*) )*)
-    $vis:vis /* require a struct */ struct $name:ident ($ty:ty) $(< ($($generics_bindings:tt)*) >)? where ($($generics_where:tt)*) {
+    $vis:vis /* require a struct */ struct $name:ident (($ty:ty) ($($generics_bindings:tt)*) ($($generics_inner:tt)*) where ($($generics_where:tt)*)) {
       $variant_name:ident $variant:tt {
         $(
           $fieldvis:vis $fieldnameident:ident @ $fieldname:tt : $fieldty:ty,
@@ -22,7 +22,7 @@ macro_rules! HeapSize {
     }
   ) => {
     with_spans!{
-      impl $(< $($generics_bindings)* >)? $crate::HeapSize for $ty where
+      impl $($generics_bindings)* $crate::HeapSize for $ty where
         $($generics_where)*
         $(
           spanned!($fieldty => $fieldty: $crate::HeapSize,)

--- a/examples/newtype_from.rs
+++ b/examples/newtype_from.rs
@@ -3,7 +3,7 @@ use rules_derive::rules_derive;
 macro_rules! NewtypeFrom {
   (
     ($( ($($attr:tt)*) )*)
-    $vis:vis struct $name:ident ($ty:ty) $(< ($($generics_bindings:tt)*) >)? where ($($generics_where:tt)*) {
+    $vis:vis struct $name:ident (($ty:ty) ($($generics_bindings:tt)*) ($($generics_inner:tt)*) where ($($generics_where:tt)*)) {
       $variant_name:ident ($variant_style:ident $($qualified_variant:tt)*) {
           // We require the first field to be the main (nonzero-sized) field.
           $main_fieldvis:vis $main_fieldnameident:ident @ $main_fieldname:tt : $main_fieldty:ty,
@@ -15,17 +15,13 @@ macro_rules! NewtypeFrom {
     }
   ) => {
     ::rules_derive::with_spans! {
-      // We insert the `T: From<$main_fieldty>` generic parameter here. Rust requires that lifetime
-      // bindings come first and non-lifetime bindings (types and consts) come after. Given that 
-      // `T: From<$main_fieldty>` is a non-lifetime binding, we insert it at the end of all the other
-      // bindings. If we were adding a lifetime binding, we'd insert it at the beginning of all the
-      // other bindings.
-      //
-      // Additionally, instead of wrapping the generics in `$(< ... >)?``, we wrap them in `< ... >`.
-      // In other words, the impl generics must always be present.
-      impl < $($($generics_bindings)*)* 
-             FromType
-           >
+      // We insert an extra `FromType` generic parameter into the impl. We splice
+      // in the type's own parameters with `$generics_inner` -- the impl bindings
+      // *without* the surrounding `<` and `>` -- so we can place `FromType`
+      // alongside them. We put `FromType` first because Rust requires lifetime
+      // parameters to precede type and const parameters; if the type had its own
+      // lifetimes we'd instead append `FromType` after `$generics_inner`.
+      impl <FromType, $($generics_inner)*>
           ::std::convert::From<FromType> for $ty where
         $($generics_where)*
         $main_fieldty: std::convert::From<FromType>,
@@ -35,7 +31,7 @@ macro_rules! NewtypeFrom {
       {
         #[inline]
         fn from(value: FromType) -> Self {
-          $($qualified_variant)* { 
+          $($qualified_variant)* {
             $main_fieldname: ::std::convert::From::from(value),
             $(
               $empty_fieldname: $crate::ZeroSized::ZERO_SIZED_VALUE,
@@ -62,10 +58,10 @@ struct SimpleNewtype(u64);
 struct NewtypeWithZeroSizedFields(u64, std::marker::PhantomData<u8>);
 
 #[rules_derive(NewtypeFrom)]
-struct GenericNewtype<'a, T>(&'a u64, std::marker::PhantomData<T>);
+struct GenericNewtype<T>(u64, std::marker::PhantomData<T>);
 
 fn main() {
   assert_eq!(1u64, SimpleNewtype::from(1u16).0);
   assert_eq!(1u64, NewtypeWithZeroSizedFields::from(1u16).0);
-  assert_eq!(1u64, *GenericNewtype::<'_, u64>::from(&1u64).0);
+  assert_eq!(1u64, GenericNewtype::<u64>::from(1u16).0);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,10 @@
 //! This library allows you to define custom deriving instances using
 //! `macro_rules!` macros rather than proc-macros. This is often much simpler.
-//! 
+//!
 //! # Getting started
-//! 
+//!
 //! Define a deriving macro with `macro_rules!()`:
-//! 
+//!
 //! ```ignore
 //! macro_rules! MyTrait {
 //!   (/* see `rules_derive` for definition of signature */) => {
@@ -15,55 +15,68 @@
 //!   }
 //! }
 //! ```
-//! 
+//!
 //! Then use it under the `rules_derive` attribute:
-//! 
+//!
 //! ```ignore
 //! #[rules_derive(MyTrait)]
 //! struct MyType { x: u32, y: String }
 //! ```
-//! 
+//!
 //! The macro definition can be in the same crate or file as its use.
-//! 
+//!
 //! See full examples [in the `examples` directory](https://github.com/MatX-inc/rules_derive/tree/main/examples).
-//! 
+//!
 //! # Tutorial
-//! 
+//!
 //! See the [announcement blog post](http://matx.com/research/rules_derive) for a tutorial.
-//! 
+//!
 //! # Parsed syntax
-//! 
-//! The `rules_derive` macro parses any `enum`/`struct` definition into a simpler-to-parse format, which it then
-//! passes to your macro. The primary transformations it does are:
-//! 
-//! * Convert all enum/struct syntaxes and named-field/unnamed-field/unit syntaxes into a uniform sum-of-products
-//!   syntax.
-//! * Convert any generic parameters in the typical ways needed for `impl` headers.
-//! 
+//!
+//! The `rules_derive` macro parses any `enum`/`struct` definition into a
+//! simpler-to-parse format, which it then passes to your macro. The primary
+//! transformations it does are:
+//!
+//! * Convert all enum/struct syntaxes and named-field/unnamed-field/unit
+//!   syntaxes into a uniform sum-of-products syntax.
+//! * Convert any generic parameters in the typical ways needed for `impl`
+//!   headers.
+//!
 //! The motivation for these transformations is given in the [announcement blog post](http://matx.com/research/rules_derive).
 //! Here is an example of the effect of this transformation:
-//! 
+//!
 //! ```ignore
 //! // Rust type definition:
 //! #[rustfmt::skip]
-//! pub enum Foo<T: Clone = u8> where u8: Into<T> { 
+//! pub enum Foo<T: Clone = u8> where u8: Into<T> {
 //!     A { x: T },
 //!     B,
 //!     C(u8),
 //! }
-//! 
+//!
 //! // rules_derive-transformed type definition:
-//! ((#[rustfmt::skip])) 
-//! pub enum Foo((Foo<T>) (<T: Clone>) where (u8: Into<T>,))
+//! ((#[rustfmt::skip]))
+//! pub enum Foo ((Foo<T>) (<T: Clone>) (T: Clone) where (u8: Into<T>,))
 //! {
-//!     A(named Foo::A) { field__x @ x : T, } 
-//!     B(unit Foo::B) {}
-//!     C(unnamed Foo::C) { field__0 @ 0 : u8, }
+//!     A (named Foo::A) { f_x @ x : T, }
+//!     B (unit Foo::B) {}
+//!     C (unnamed Foo::C) { tuple_field_0 @ 0 : u8, }
 //! }
 //! ```
-//! 
-//! This transformed type definition is then passed to your macro. You can see the `macro_rules!` header
-//! that accepts this transformed type definition on the [`rules_derive`] documentation.
+//!
+//! The generics appear three times: `(Foo<T>)` for naming the type, `(<T:
+//! Clone>)` (`generics_bindings`, with the angle brackets) for `impl` headers,
+//! and `(T: Clone)` (`generics_inner`, without the angle brackets) for splicing
+//! extra parameters into an `impl`.
+//!
+//! This transformed type definition is then passed to your macro. You can see
+//! the `macro_rules!` header that accepts this transformed type definition on
+//! the [`rules_derive`] documentation.
+
+// `Span::join` (used by `spanned!` under the `nightly` feature to widen a span
+// across multiple tokens) is gated behind the unstable `proc_macro_span`
+// feature. Enable it only when the `nightly` feature is on.
+#![cfg_attr(feature = "nightly", feature(proc_macro_span))]
 
 use proc_macro::Delimiter;
 use proc_macro::Group;
@@ -82,7 +95,8 @@ use parsing::*;
 /// some of the repetitions (to specialize for a specific number of fields or
 /// variants) or specializing `$tystyle` to `struct` or `enum`.
 ///
-/// TODO: remove redundant parens around attr:tt.
+/// TODO: remove redundant parens around (a) attr:tt, (b) `ty, generics_bindings
+/// where generics_where`.
 ///
 /// The full protocol:
 ///
@@ -90,7 +104,7 @@ use parsing::*;
 /// macro_rules! Foo {
 ///   (
 ///     ($( ($($attr:tt)*) )*)
-///     $vis:vis $tystyle:ident $name:ident ($ty:ty) $( <( $($generics_bindings:tt)* )> )? where ($($generics_where:tt)*) {
+///     $vis:vis $tystyle:ident $name:ident (($ty:ty) ($($generics_bindings:tt)*) ($($generics_inner:tt)*) where ($($generics_where:tt)*)) {
 ///       $(
 ///         $variant_name:ident ($variant_style:ident $($qualified_variant:tt)*) $(= ($discriminant:expr))? {
 ///           $(
@@ -102,27 +116,25 @@ use parsing::*;
 ///   ) => { ... }
 /// }
 /// ```
-/// 
-/// Here is an example of a Rust type definition being transformed into this protocol:
-/// 
+///
 /// Here is an example of the effect of this transformation:
-/// 
+///
 /// ```ignore
 /// // Rust type definition:
 /// #[rustfmt::skip]
-/// pub enum Foo<T: Clone = u8> where u8: Into<T> { 
+/// pub enum Foo<T: Clone = u8> where u8: Into<T> {
 ///     A { x: T },
 ///     B,
 ///     C(u8),
 /// }
-/// 
+///
 /// // rules_derive-transformed type definition:
-/// ((#[rustfmt::skip])) 
-/// pub enum Foo(Foo<T>) <(T: Clone,)> where (u8: Into<T>,)
+/// ((#[rustfmt::skip]))
+/// pub enum Foo ((Foo<T>) (<T: Clone>) (T: Clone) where (u8: Into<T>,))
 /// {
-///     A(named Foo::A) { field__x @ x : T, } 
-///     B(unit Foo::B) {}
-///     C(unnamed Foo::C) { field__0 @ 0 : u8, }
+///     A (named Foo::A) { f_x @ x : T, }
+///     B (unit Foo::B) {}
+///     C (unnamed Foo::C) { tuple_field_0 @ 0 : u8, }
 /// }
 /// ```
 ///
@@ -247,7 +259,7 @@ fn rules_derive_inner(item: TokenStream) -> Result<TokenStream> {
   description.push(type_name.clone());
 
   // GenericParams?
-  let (ty, generics_bindings) = parse_generics(&mut item, &type_name)?;
+  let (ty, generics_bindings, generics_inner) = parse_generics(&mut item, &type_name)?;
 
   // StructStruct → ... WhereClause? ( {
   //   StructFields? } | ; )
@@ -271,7 +283,10 @@ fn rules_derive_inner(item: TokenStream) -> Result<TokenStream> {
             // StructStruct → ... { StructFields? }
             let fields = parse_named_fields(group.stream())?;
             variants.push(type_name.clone());
-            variants.push(parens([with_span(group.span_open(), ident("named")), type_name.clone()]));
+            variants.push(parens([
+              with_span(group.span_open(), ident("named")),
+              type_name.clone(),
+            ]));
             variants.push(braces(fields));
           }
           TyStyle::Enum => {
@@ -378,7 +393,10 @@ fn rules_derive_inner(item: TokenStream) -> Result<TokenStream> {
           //   )*
           // }
           variants.push(type_name.clone()); // $variant_name
-          variants.push(parens([with_span(group.span_open(), ident("unnamed")), type_name.clone()]));
+          variants.push(parens([
+            with_span(group.span_open(), ident("unnamed")),
+            type_name.clone(),
+          ]));
           variants.push(braces(parse_unnamed_fields(group.stream())?));
           parse_where_clause(&mut item, &mut generics_where)?;
           item.next()?; // ';'
@@ -394,15 +412,21 @@ fn rules_derive_inner(item: TokenStream) -> Result<TokenStream> {
       }
       // Unit struct.
       variants.push(type_name.clone()); // $variant_name
-      variants.push(parens([with_span(punct.span(), ident("unit")), type_name.clone()]));
+      variants.push(parens([
+        with_span(punct.span(), ident("unit")),
+        type_name.clone(),
+      ]));
       variants.push(braces([]));
     }
     _ => return item.error(&"Parse error"),
   }
-  description.push(parens(ty));
-  description.extend(generics_bindings);
-  description.push(ident("where"));
-  description.push(parens(generics_where));
+  description.push(parens([
+    parens(ty),
+    parens(generics_bindings),
+    parens(generics_inner),
+    ident("where"),
+    parens(generics_where),
+  ]));
   description.push(braces(variants));
 
   // Parse `#[rules_derive(Foo(...), Bar)]` attribute.
@@ -446,7 +470,7 @@ fn rules_derive_inner(item: TokenStream) -> Result<TokenStream> {
 }
 
 /// Creates an identifier from the concatenation of identifiers and literals.
-/// 
+///
 /// For example, `make_ident!(foo, "bar", 123)` becomes `foobar123`.
 #[proc_macro]
 pub fn make_ident(item: TokenStream) -> TokenStream { render_macro_result(make_ident_inner(item)) }
@@ -478,7 +502,8 @@ fn make_ident_inner(item: TokenStream) -> Result<TokenStream> {
 ///
 /// Within the scope of an outer `with_spans!(...)` invocation, you may use
 /// `spanned!(foo => tokens...)` to cause the `tokens...` to be annotated with
-/// the source location attached to `foo`. The `foo` must be a single token-tree.
+/// the source location attached to `foo`. The `foo` must be a single
+/// token-tree.
 ///
 /// The most common use case is to attribute missing instances in a
 /// `rules_derive` macro to a particular field of the source type. For this use
@@ -548,7 +573,12 @@ fn process_stream(
                     // Multiple tokens inside. Use them to set the span and then stop recursing.
                     #[cfg(feature = "nightly")]
                     {
-                      inner_span = first.span().join(last.span());
+                      // `Span::join` returns `None` when the two spans are in
+                      // different source files; fall back to the first span.
+                      inner_span = first
+                        .span()
+                        .join(last.span())
+                        .unwrap_or_else(|| first.span());
                     }
                     #[cfg(not(feature = "nightly"))]
                     {

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -71,9 +71,9 @@ impl ParseState {
 
   pub(crate) fn span(&self) -> Span {
     self.peeks[0]
-    .as_ref()
-    .map(|t| t.span())
-    .unwrap_or(self.last_span)
+      .as_ref()
+      .map(|t| t.span())
+      .unwrap_or(self.last_span)
   }
 
   pub(crate) fn peek_ident(&self, n: usize, expected_ident: &str) -> bool {
@@ -253,15 +253,11 @@ pub(crate) fn parse_where_clause(
     let result_len = result.len();
     parse_typelike(input, result, |input| {
       match &input.peeks[0] {
-        Some(TokenTree::Group(group)) => {
-          if group.delimiter() == proc_macro::Delimiter::Brace {
-            return true;
-          }
+        Some(TokenTree::Group(group)) if group.delimiter() == proc_macro::Delimiter::Brace => {
+          return true;
         }
-        Some(TokenTree::Punct(punct)) => {
-          if punct.as_char() == ';' {
-            return true;
-          }
+        Some(TokenTree::Punct(punct)) if punct.as_char() == ';' => {
+          return true;
         }
         _ => {}
       }
@@ -284,11 +280,14 @@ fn ensure_trailing_comma_if_nonempty(result: &mut Vec<TokenTree>, start_position
 ///  1) `type_tokens`: Generics without bounds or defaults, for instantiating
 ///     the type itself.
 ///  2) `generics_bindings`: Generics without defaults, for declaring generics
-///     in impls.
+///     in impls. Includes the surrounding `<` and `>`.
+///  3) `generics_inner`: Same content as `generics_bindings` but WITHOUT the
+///     surrounding `<` and `>`. Useful for injecting extra generic parameters
+///     into an impl, e.g. `impl<ExtraParam, $($generics_inner)*> ...`.
 pub(crate) fn parse_generics(
   input: &mut ParseState,
   name: &TokenTree,
-) -> Result<(Vec<TokenTree>, Vec<TokenTree>)> {
+) -> Result<(Vec<TokenTree>, Vec<TokenTree>, Vec<TokenTree>)> {
   let mut type_tokens: Vec<TokenTree> = vec![name.clone()];
 
   let mut generics_bindings: Vec<TokenTree> = Vec::new();
@@ -296,17 +295,13 @@ pub(crate) fn parse_generics(
     // GenericParams → < ( GenericParam ( , GenericParam )* ,? )? >
     let open_lt = input.next()?; // '<'
     type_tokens.push(open_lt.clone());
+    generics_bindings.push(open_lt);
 
     loop {
       if input.peek_punct(0, b">") {
         let close_gt = input.next()?; // '>'
         type_tokens.push(close_gt.clone());
-        ensure_trailing_comma_if_nonempty(&mut generics_bindings, 0);
-        generics_bindings = vec![
-          open_lt,
-          parens(generics_bindings),
-          close_gt,
-        ];
+        generics_bindings.push(close_gt);
         break;
       }
 
@@ -322,17 +317,17 @@ pub(crate) fn parse_generics(
             // ConstParam →
             //   const IDENTIFIER : Type
             //     ( = BlockExpression | IDENTIFIER | -? LiteralExpression )?
-
             generics_bindings.push(param_start); // const
             let const_ident = input.next()?; // IDENTIFIER
             type_tokens.push(const_ident.clone()); // IDENTIFIER
             generics_bindings.push(const_ident); // IDENTIFIER
-            generics_bindings.push(input.next()?); // :
+            generics_bindings.push(input.next()?); // ':'
 
             // Type
             parse_typelike(input, &mut generics_bindings, |input| {
               input.peek_puncts(0, &[b"=", b",", b">"]).is_some()
             })?;
+
             if input.peek_punct(0, b"=") {
               input.next()?; // '='
               let const_value = input.next()?;
@@ -401,12 +396,20 @@ pub(crate) fn parse_generics(
       }
       if input.peek_punct(0, b",") {
         let comma = input.next()?; // ','
-        generics_bindings.push(comma.clone());
-        type_tokens.push(comma);
+        type_tokens.push(comma.clone());
+        generics_bindings.push(comma);
       }
     }
   }
-  Ok((type_tokens, generics_bindings))
+  // Derive generics_inner by stripping the `<` and `>` from generics_bindings,
+  // rather than the other way around, to preserve the original source spans on
+  // the `<`/`>` tokens for better error diagnostics.
+  let generics_inner = if generics_bindings.len() > 2 {
+    generics_bindings[1..generics_bindings.len() - 1].to_vec()
+  } else {
+    Vec::new()
+  };
+  Ok((type_tokens, generics_bindings, generics_inner))
 }
 
 pub(crate) fn parse_named_fields(input: TokenStream) -> Result<Vec<TokenTree>> {
@@ -426,8 +429,14 @@ pub(crate) fn parse_named_fields(input: TokenStream) -> Result<Vec<TokenTree>> {
     // TODO: attrs.
     skip_outer_attributes(&mut input)?;
     parse_visibility(&mut input, &mut result);
-    let field_name = input.next()?; // IDENTIFIER
-    let field_name_ident = Ident::new(&format!("field__{}", field_name), Span::call_site());
+
+    // IDENTIFIER
+    let field_name = input.next()?;
+    // Handle `r#` raw identifiers, for example `r#if` -> `f_if`.
+    let field_name_str = field_name.to_string();
+    let stripped = field_name_str.strip_prefix("r#").unwrap_or(&field_name_str);
+    let field_name_ident = Ident::new(&format!("f_{}", stripped), Span::call_site());
+
     result.push(TokenTree::Ident(field_name_ident)); // $fieldnameident:ident
     result.push(punct('@')); // @
     result.push(field_name); // $fieldname:tt
@@ -466,7 +475,7 @@ pub(crate) fn parse_unnamed_fields(input: TokenStream) -> Result<Vec<TokenTree>>
     // TODO: attrs.
     skip_outer_attributes(&mut input)?;
     parse_visibility(&mut input, &mut result);
-    let field_name_ident = Ident::new(&format!("field__{}", field_index), Span::call_site());
+    let field_name_ident = Ident::new(&format!("tuple_field_{}", field_index), Span::call_site());
     result.push(TokenTree::Ident(field_name_ident)); // $fieldnameident:ident
     result.push(punct('@')); // @
     result.push(TokenTree::Literal(Literal::usize_unsuffixed(field_index))); // $fieldname:tt


### PR DESCRIPTION
## Summary

Releases 0.3.0, bringing the published crate in line with the version used
internally at MatX. This is a **breaking change** to the protocol that deriving
macros match against.

## Breaking changes

- **Protocol shape.** The transformed type definition is now wrapped in a single
  parenthesized group:
  `$vis $tystyle $name (($ty) ($generics_bindings) ($generics_inner) where ($generics_where)) { … }`.
  `generics_bindings` now includes its surrounding `<` `>`, so impl headers
  become `impl $($generics_bindings)* Trait for $ty` (no longer wrapped in
  `$(< … >)?`).
- **New `generics_inner` stream.** A third generics stream — the impl bindings
  *without* the surrounding angle brackets — makes it possible to splice extra
  type parameters into an impl, e.g. `impl<Extra, $($generics_inner)*> …`. See
  `examples/newtype_from.rs`.
- **Field binding identifiers.** Generated field bindings are now `f_<name>`
  (named fields, with any `r#` raw prefix stripped) and `tuple_field_<n>` (tuple
  fields), replacing `field__…`. This makes raw-identifier fields such as `r#if`
  usable with `make_ident!`.

## Other

- Fixes the `nightly` feature, which no longer compiled: gate `proc_macro_span`
  and handle `Span::join` now returning `Option<Span>`.

## Testing

- `cargo build` / `cargo test` and all examples pass; the optional `nightly`
  feature builds and runs under a nightly toolchain.
- The new behavior is exercised by the examples: `generics_inner` in
  `examples/newtype_from.rs`, and raw-identifier fields in
  `examples/custom_clone_and_eq.rs`.
